### PR TITLE
Specify both story and job can be return from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Example: https://hacker-news.firebaseio.com/v0/maxitem.json?print=pretty
 
 Up to 500 top and new stories are at `/v0/topstories` and `/v0/newstories`. Best stories are at `/v0/beststories`.
 
+|         | `topstories` | `newstories` | `beststories` |
+|---------|--------------|--------------|---------------|
+| `story` | ✔            | ✔            | ✔             |
+| `job`   | ✔            |              |               |
+
+
 Example: https://hacker-news.firebaseio.com/v0/topstories.json?print=pretty
 
 ```javascript


### PR DESCRIPTION
A small documentation update, to be clear that those "stories" endpoint may return item that is not type "story".

![No. 78 is a job, not a story](https://user-images.githubusercontent.com/3873011/61184827-54198b00-a652-11e9-94e8-b3bf94274534.png)

(:point_up: [no. 78 is a job, not a story. Taken on 2019/07/14](https://hacker-news.firebaseio.com/v0/item/20431145.json?print=pretty))

Or is it possible for those endpoints to return any type of item? if that's the case, I think it'd still be nice to point it out.