### PR TITLE
Remove url from "Ask HN" responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ ask: https://hacker-news.firebaseio.com/v0/item/121003.json?print=pretty
   "text" : "<i>or</i> HN: the Next Iteration<p>I get the impression that with Arc being released a lot of people who never had time for HN before are suddenly dropping in more often. (PG: what are the numbers on this? I'm envisioning a spike.)<p>Not to say that isn't great, but I'm wary of Diggification. Between links comparing programming to sex and a flurry of gratuitous, ostentatious  adjectives in the headlines it's a bit concerning.<p>80% of the stuff that makes the front page is still pretty awesome, but what's in place to keep the signal/noise ratio high? Does the HN model still work as the community scales? What's in store for (++ HN)?",
   "time" : 1203647620,
   "title" : "Ask HN: The Arc Effect",
-  "type" : "story",
-  "url" : ""
+  "type" : "story"
 }
 ```
 


### PR DESCRIPTION
The response currently doesn't include url attribute, so the
documentation was misleading.